### PR TITLE
fix(EAV-858): make vMix polling more robust

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
         "@types/webmidi": "^2.0.10",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.2",
-        "typescript": "^5.3.3"
+        "typescript": "^5.6.3"
     },
     "dependencies": {
         "@babel/core": "^7.23.9",

--- a/server/src/utils/mixerConnections/VMixMixerConnection.ts
+++ b/server/src/utils/mixerConnections/VMixMixerConnection.ts
@@ -33,6 +33,8 @@ import {
 import { LinkableMode, MixerConnection } from '.'
 import { STORAGE_FOLDER } from '../SettingsStorage'
 import { Preset } from './productSpecific/vMixPreset'
+import { VMixPoller } from './productSpecific/VMixPoller'
+import { VMixConnectionWatchdog } from './productSpecific/VMixConnectionWatchdog'
 
 enum PrivateDataTag {
     INPUT_NUMBER = 'inputNumber',
@@ -72,7 +74,9 @@ export class VMixMixerConnection implements MixerConnection {
     vMixCommandConnection: ConnectionTCP
     /** We use a separate connection for updates to prevent blocking any commands */
     vMixFeedbackConnection: ConnectionTCP
-    vMixXmlPollingInterval: NodeJS.Timeout
+
+    private poller: VMixPoller
+    private watchdog: VMixConnectionWatchdog
 
     audioOn: Record<string, boolean> = {}
     lastLevel: Record<string, number> = {}
@@ -94,6 +98,27 @@ export class VMixMixerConnection implements MixerConnection {
 
         this.mixerProtocol = mixerProtocol
         this.mixerIndex = mixerIndex
+
+        this.watchdog = new VMixConnectionWatchdog(() => {
+            logger.warn(
+                `VMix XML not received in time, closing feedback connection`
+            )
+            this.vMixFeedbackConnection['_socket'].destroy() // this will trigger reconnect
+        })
+
+        this.poller = new VMixPoller(
+            () => {
+                this.vMixFeedbackConnection.send('XML')
+                this.watchdog.start()
+            },
+            () => this.vMixFeedbackConnection.connected(),
+            () => {
+                logger.warn(
+                    `VMix XML not received in time, using fallback poll`
+                )
+            }
+        )
+
         //If default store has been recreated multiple mixers are not created
         if (!state.channels[0].chMixerConnection[this.mixerIndex]) {
             state.channels[0].chMixerConnection[this.mixerIndex] = {
@@ -150,6 +175,7 @@ export class VMixMixerConnection implements MixerConnection {
 
     private setupMixerConnection() {
         this.vMixCommandConnection.on('connect', () => {
+            logger.info('VMix command connection established')
             logger.info('Receiving state of desk')
             this.sendInitialCommands()
             this.awaitingFirstXml = true
@@ -159,9 +185,9 @@ export class VMixMixerConnection implements MixerConnection {
             global.mainThreadHandler.updateFullClientStore()
             logger.error(error)
         })
-        this.vMixCommandConnection['_socket'].on('disconnect', () => {
+        this.vMixCommandConnection.on('close', () => {
             this.setMixerOnlineState(false)
-            logger.info('Lost VMix connection')
+            logger.warn('Lost VMix command connection')
         })
 
         logger.info(
@@ -174,16 +200,30 @@ export class VMixMixerConnection implements MixerConnection {
             if (this.awaitingFirstXml) {
                 this.onReceivedFirstState()
             }
-            this.handleXml(xml)
+            try {
+                this.handleXml(xml)
+            } catch (e) {
+                logger.error(e)
+            }
+            // Clear watchdog and schedule next poll
+            this.watchdog.stop()
+            this.poller.onResponseReceived()
         })
 
         this.vMixFeedbackConnection.on('connect', () => {
-            this.vMixXmlPollingInterval = setInterval(() => {
-                this.vMixFeedbackConnection.send('XML')
-            }, 80)
+            logger.info('VMix feedback connection established')
+            // deferring it so that the connection is fully ready (it processes events itself AFTER it emits them to subscribers)
+            setImmediate(() => {
+                this.poller.start()
+            })
         })
-        this.vMixFeedbackConnection['_socket'].on('disconnect', () => {
-            clearInterval(this.vMixXmlPollingInterval)
+        this.vMixFeedbackConnection.on('error', (error: any) => {
+            logger.error(error)
+        })
+        this.vMixFeedbackConnection.on('close', () => {
+            this.poller.stop()
+            this.watchdog.stop()
+            logger.warn('Lost VMix feedback connection')
         })
     }
 
@@ -231,15 +271,8 @@ export class VMixMixerConnection implements MixerConnection {
             d.volumeF2 !== undefined
                 ? Math.pow(parseFloat(d.volumeF2 || '0'), 0.25)
                 : undefined
-        // Use -Infinity for silence to ensure VU meters completely drop to baseline when no audio present
-        d.meterF1 =
-            d.meterF1 > 0
-                ? (9.555 * Math.log(d.meterF1)) / Math.log(3)
-                : -Infinity
-        d.meterF2 =
-            d.meterF2 > 0
-                ? (9.555 * Math.log(d.meterF2)) / Math.log(3)
-                : -Infinity
+        d.meterF1 = (9.555 * Math.log(d.meterF1 || 0)) / Math.log(3)
+        d.meterF2 = (9.555 * Math.log(d.meterF2 || 0)) / Math.log(3)
         d.muted = d.muted ? d.muted === 'True' : true
         d.solo = d.solo === 'True'
         d.gainDb = parseFloat(d.gainDb || '0') / 24
@@ -460,7 +493,7 @@ export class VMixMixerConnection implements MixerConnection {
                 assignedFaderIndex,
                 VuType.Channel,
                 vuIndex,
-                input.meterF1 === -Infinity ? 0 : dbToFloat(input.meterF1 + 12)
+                dbToFloat(input.meterF1 + 12)
             ) // send 0 directly for silence, otherwise convert
         } else {
             sendVuLevel(
@@ -631,8 +664,9 @@ export class VMixMixerConnection implements MixerConnection {
         const returnFeedNumber = this.getReturnFeedNumber(inputNumber)
         let preset: ChannelMatrixPreset
 
-        const prefix = state.settings[0].mixers[this.mixerIndex].channelMatrixPrefix ||
-                      this.mixerProtocol.channelMatrixPrefix
+        const prefix =
+            state.settings[0].mixers[this.mixerIndex].channelMatrixPrefix ||
+            this.mixerProtocol.channelMatrixPrefix
         const lrPresetName = this.mixerProtocol.lrPreset
 
         if (returnFeedNumber > 0 && prefix && lrPresetName) {
@@ -673,8 +707,9 @@ export class VMixMixerConnection implements MixerConnection {
      * Returns the number after the prefix (e.g., "EXT 1" returns 1, "RTN 3" returns 3), or 0 if no match.
      */
     private getReturnFeedNumber(inputNumber: number): number {
-        const prefix = state.settings[0].mixers[this.mixerIndex].channelMatrixPrefix ||
-                      this.mixerProtocol.channelMatrixPrefix
+        const prefix =
+            state.settings[0].mixers[this.mixerIndex].channelMatrixPrefix ||
+            this.mixerProtocol.channelMatrixPrefix
 
         // If no prefix configured, use standard presets
         if (!prefix) return 0

--- a/server/src/utils/mixerConnections/VMixMixerConnection.ts
+++ b/server/src/utils/mixerConnections/VMixMixerConnection.ts
@@ -36,6 +36,15 @@ import { Preset } from './productSpecific/vMixPreset'
 import { VMixPoller } from './productSpecific/VMixPoller'
 import { VMixConnectionWatchdog } from './productSpecific/VMixConnectionWatchdog'
 
+/** If no XML received within 2 seconds, we reconnect the feedback connection */
+const CONNECTION_WATCHDOG_TIMEOUT_MS = 2000
+/** We usually poll 80 milliseconds after last XML requested(!) - this is so frequent in order to maintain fairly smooth vu-meters, as well as keep the state up to date */
+const DEFAULT_POLL_INTERVAL_MS = 80
+/** We try to limit polling to at least 20 milliseconds since last XML received(!) in order not to flood vMix too much */
+const DEFAULT_MIN_POLL_INTERVAL_MS = 20
+/** We fallback to doing an additional poll in 500 milliseconds if no XML response is received */
+const FALLBACK_POLL_INTERVAL_MS = 500
+
 enum PrivateDataTag {
     INPUT_NUMBER = 'inputNumber',
     LINKABLE = 'linkable',
@@ -99,12 +108,15 @@ export class VMixMixerConnection implements MixerConnection {
         this.mixerProtocol = mixerProtocol
         this.mixerIndex = mixerIndex
 
-        this.watchdog = new VMixConnectionWatchdog(() => {
-            logger.warn(
-                `VMix XML not received in time, closing feedback connection`
-            )
-            this.vMixFeedbackConnection['_socket'].destroy() // this will trigger reconnect
-        })
+        this.watchdog = new VMixConnectionWatchdog(
+            () => {
+                logger.warn(
+                    `VMix XML not received in time, closing feedback connection`
+                )
+                this.vMixFeedbackConnection['_socket'].destroy() // this will trigger reconnect
+            },
+            CONNECTION_WATCHDOG_TIMEOUT_MS // If no XML received within this amount, reconnect the feedback connection
+        )
 
         this.poller = new VMixPoller(
             () => {
@@ -116,7 +128,10 @@ export class VMixMixerConnection implements MixerConnection {
                 logger.warn(
                     `VMix XML not received in time, using fallback poll`
                 )
-            }
+            },
+            DEFAULT_POLL_INTERVAL_MS,
+            DEFAULT_MIN_POLL_INTERVAL_MS,
+            FALLBACK_POLL_INTERVAL_MS
         )
 
         //If default store has been recreated multiple mixers are not created
@@ -187,7 +202,7 @@ export class VMixMixerConnection implements MixerConnection {
         })
         this.vMixCommandConnection.on('close', () => {
             this.setMixerOnlineState(false)
-            logger.warn('Lost VMix command connection')
+            logger.warn('VMix command connection lost')
         })
 
         logger.info(
@@ -223,7 +238,7 @@ export class VMixMixerConnection implements MixerConnection {
         this.vMixFeedbackConnection.on('close', () => {
             this.poller.stop()
             this.watchdog.stop()
-            logger.warn('Lost VMix feedback connection')
+            logger.warn('VMix feedback connection lost')
         })
     }
 

--- a/server/src/utils/mixerConnections/VMixMixerConnection.ts
+++ b/server/src/utils/mixerConnections/VMixMixerConnection.ts
@@ -121,7 +121,6 @@ export class VMixMixerConnection implements MixerConnection {
         this.poller = new VMixPoller(
             () => {
                 this.vMixFeedbackConnection.send('XML')
-                this.watchdog.start()
             },
             () => this.vMixFeedbackConnection.connected(),
             () => {
@@ -220,8 +219,8 @@ export class VMixMixerConnection implements MixerConnection {
             } catch (e) {
                 logger.error(e)
             }
-            // Clear watchdog and schedule next poll
-            this.watchdog.stop()
+            // Restart watchdog and schedule next poll
+            this.watchdog.start()
             this.poller.onResponseReceived()
         })
 
@@ -230,6 +229,7 @@ export class VMixMixerConnection implements MixerConnection {
             // deferring it so that the connection is fully ready (it processes events itself AFTER it emits them to subscribers)
             setImmediate(() => {
                 this.poller.start()
+                this.watchdog.start()
             })
         })
         this.vMixFeedbackConnection.on('error', (error: any) => {

--- a/server/src/utils/mixerConnections/productSpecific/VMixConnectionWatchdog.ts
+++ b/server/src/utils/mixerConnections/productSpecific/VMixConnectionWatchdog.ts
@@ -1,0 +1,22 @@
+/** If no XML received within 2 seconds, reconnect the feedback connection */
+const CONNECTION_WATCHDOG_MS = 2000
+
+export class VMixConnectionWatchdog {
+    private watchdogTimeout: NodeJS.Timeout | null = null
+
+    constructor(private readonly onTimeout: () => void) {}
+
+    start() {
+        this.stop()
+        this.watchdogTimeout = setTimeout(() => {
+            this.onTimeout()
+        }, CONNECTION_WATCHDOG_MS)
+    }
+
+    stop() {
+        if (this.watchdogTimeout) {
+            clearTimeout(this.watchdogTimeout)
+            this.watchdogTimeout = null
+        }
+    }
+}

--- a/server/src/utils/mixerConnections/productSpecific/VMixConnectionWatchdog.ts
+++ b/server/src/utils/mixerConnections/productSpecific/VMixConnectionWatchdog.ts
@@ -1,16 +1,16 @@
-/** If no XML received within 2 seconds, reconnect the feedback connection */
-const CONNECTION_WATCHDOG_MS = 2000
-
 export class VMixConnectionWatchdog {
     private watchdogTimeout: NodeJS.Timeout | null = null
 
-    constructor(private readonly onTimeout: () => void) {}
+    constructor(
+        private readonly onTimeout: () => void,
+        private readonly timeoutMs: number
+    ) {}
 
     start() {
         this.stop()
         this.watchdogTimeout = setTimeout(() => {
             this.onTimeout()
-        }, CONNECTION_WATCHDOG_MS)
+        }, this.timeoutMs)
     }
 
     stop() {

--- a/server/src/utils/mixerConnections/productSpecific/VMixPoller.ts
+++ b/server/src/utils/mixerConnections/productSpecific/VMixPoller.ts
@@ -1,0 +1,78 @@
+/** We usually poll 80 milliseconds after last XML requested */
+const DEFAULT_POLL_INTERVAL_MS = 80
+/** We try to limit polling to at least 20 milliseconds since last XML received */
+const DEFAULT_MIN_POLL_INTERVAL_MS = 20
+/** We fallback to polling aditionally in 500 milliseconds if no XML received */
+const FALLBACK_POLL_INTERVAL_MS = 500
+
+export class VMixPoller {
+    private pollingTimeout: NodeJS.Timeout | null = null
+    private lastRequestTime: number = 0
+
+    constructor(
+        private readonly sendRequest: () => void,
+        private readonly isConnected: () => boolean,
+        private readonly onFallbackTriggered: () => void
+    ) {}
+
+    start() {
+        this.scheduleNextPoll()
+    }
+
+    onResponseReceived() {
+        this.scheduleNextPoll()
+    }
+
+    stop() {
+        this.clear()
+    }
+
+    private clear() {
+        if (this.pollingTimeout) {
+            clearTimeout(this.pollingTimeout)
+            this.pollingTimeout = null
+        }
+    }
+
+    private scheduleNextPoll() {
+        this.clear()
+
+        if (!this.isConnected()) {
+            return
+        }
+
+        const elapsed = this.lastRequestTime
+            ? performance.now() - this.lastRequestTime
+            : 0
+        const delay = Math.max(
+            DEFAULT_MIN_POLL_INTERVAL_MS,
+            DEFAULT_POLL_INTERVAL_MS - elapsed
+        )
+
+        this.pollingTimeout = setTimeout(() => {
+            this.sendRequestAndScheduleFallback()
+        }, delay)
+    }
+
+    private scheduleFallbackPoll() {
+        this.clear()
+
+        if (!this.isConnected()) {
+            return
+        }
+
+        this.pollingTimeout = setTimeout(() => {
+            this.onFallbackTriggered()
+            this.sendRequestAndScheduleFallback()
+        }, FALLBACK_POLL_INTERVAL_MS)
+    }
+
+    private sendRequestAndScheduleFallback() {
+        if (!this.isConnected()) {
+            return
+        }
+        this.lastRequestTime = performance.now()
+        this.sendRequest()
+        this.scheduleFallbackPoll()
+    }
+}

--- a/server/src/utils/mixerConnections/productSpecific/VMixPoller.ts
+++ b/server/src/utils/mixerConnections/productSpecific/VMixPoller.ts
@@ -1,10 +1,3 @@
-/** We usually poll 80 milliseconds after last XML requested */
-const DEFAULT_POLL_INTERVAL_MS = 80
-/** We try to limit polling to at least 20 milliseconds since last XML received */
-const DEFAULT_MIN_POLL_INTERVAL_MS = 20
-/** We fallback to polling aditionally in 500 milliseconds if no XML received */
-const FALLBACK_POLL_INTERVAL_MS = 500
-
 export class VMixPoller {
     private pollingTimeout: NodeJS.Timeout | null = null
     private lastRequestTime: number = 0
@@ -12,7 +5,10 @@ export class VMixPoller {
     constructor(
         private readonly sendRequest: () => void,
         private readonly isConnected: () => boolean,
-        private readonly onFallbackTriggered: () => void
+        private readonly onFallbackTriggered: () => void,
+        private readonly defaultPollIntervalMs: number,
+        private readonly defaultMinPollIntervalMs: number,
+        private readonly fallbackPollIntervalMs: number
     ) {}
 
     start() {
@@ -45,8 +41,8 @@ export class VMixPoller {
             ? performance.now() - this.lastRequestTime
             : 0
         const delay = Math.max(
-            DEFAULT_MIN_POLL_INTERVAL_MS,
-            DEFAULT_POLL_INTERVAL_MS - elapsed
+            this.defaultMinPollIntervalMs,
+            this.defaultPollIntervalMs - elapsed
         )
 
         this.pollingTimeout = setTimeout(() => {
@@ -64,7 +60,7 @@ export class VMixPoller {
         this.pollingTimeout = setTimeout(() => {
             this.onFallbackTriggered()
             this.sendRequestAndScheduleFallback()
-        }, FALLBACK_POLL_INTERVAL_MS)
+        }, this.fallbackPollIntervalMs)
     }
 
     private sendRequestAndScheduleFallback() {

--- a/server/src/utils/mixerConnections/productSpecific/__tests__/VMixConnectionWatchdog.spec.ts
+++ b/server/src/utils/mixerConnections/productSpecific/__tests__/VMixConnectionWatchdog.spec.ts
@@ -1,0 +1,210 @@
+import { VMixConnectionWatchdog } from '../VMixConnectionWatchdog'
+
+jest.useFakeTimers()
+
+describe('VMixConnectionWatchdog', () => {
+    let onTimeoutMock: jest.Mock
+    let watchdog: VMixConnectionWatchdog
+
+    beforeEach(() => {
+        onTimeoutMock = jest.fn()
+        watchdog = new VMixConnectionWatchdog(onTimeoutMock)
+        jest.clearAllTimers()
+    })
+
+    afterEach(() => {
+        watchdog.stop()
+    })
+
+    describe('start', () => {
+        it('should trigger timeout after 2 seconds', () => {
+            watchdog.start()
+
+            jest.advanceTimersByTime(1999)
+            expect(onTimeoutMock).not.toHaveBeenCalled()
+
+            jest.advanceTimersByTime(1)
+            expect(onTimeoutMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('should not trigger multiple timeouts when started multiple times', () => {
+            watchdog.start()
+            watchdog.start()
+            watchdog.start()
+
+            jest.advanceTimersByTime(2000)
+
+            expect(onTimeoutMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('should replace existing timeout when started again', () => {
+            watchdog.start()
+
+            jest.advanceTimersByTime(1000)
+
+            watchdog.start()
+
+            jest.advanceTimersByTime(1999)
+            expect(onTimeoutMock).not.toHaveBeenCalled()
+
+            jest.advanceTimersByTime(1)
+            expect(onTimeoutMock).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('stop', () => {
+        it('should cancel pending timeout', () => {
+            watchdog.start()
+
+            jest.advanceTimersByTime(1000)
+
+            watchdog.stop()
+
+            jest.advanceTimersByTime(1000)
+
+            expect(onTimeoutMock).not.toHaveBeenCalled()
+        })
+
+        it('should not throw when called multiple times', () => {
+            watchdog.start()
+
+            expect(() => {
+                watchdog.stop()
+                watchdog.stop()
+                watchdog.stop()
+            }).not.toThrow()
+        })
+
+        it('should not throw when called without start', () => {
+            expect(() => {
+                watchdog.stop()
+            }).not.toThrow()
+        })
+    })
+
+    describe('typical usage patterns', () => {
+        it('should monitor connection with periodic resets', () => {
+            watchdog.start()
+
+            // Simulate periodic XML responses
+            for (let i = 0; i < 10; i++) {
+                jest.advanceTimersByTime(500)
+                watchdog.start()
+            }
+
+            // Should never timeout
+            expect(onTimeoutMock).not.toHaveBeenCalled()
+        })
+
+        it('should trigger when responses stop', () => {
+            watchdog.start()
+
+            // Responses coming in regularly
+            jest.advanceTimersByTime(500)
+            watchdog.start()
+
+            jest.advanceTimersByTime(500)
+            watchdog.start()
+
+            jest.advanceTimersByTime(500)
+            watchdog.start()
+
+            // No more responses, watchdog should trigger after 2s
+            jest.advanceTimersByTime(2000)
+
+            expect(onTimeoutMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('should handle start-stop-start cycle', () => {
+            watchdog.start()
+
+            jest.advanceTimersByTime(1000)
+
+            watchdog.stop()
+
+            jest.advanceTimersByTime(5000)
+            expect(onTimeoutMock).not.toHaveBeenCalled()
+
+            watchdog.start()
+
+            jest.advanceTimersByTime(2000)
+            expect(onTimeoutMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('should handle connection loss and recovery', () => {
+            // Connection established
+            watchdog.start()
+
+            // Regular updates
+            jest.advanceTimersByTime(100)
+            watchdog.start()
+
+            jest.advanceTimersByTime(100)
+            watchdog.start()
+
+            // Connection lost, watchdog stops
+            watchdog.stop()
+
+            jest.advanceTimersByTime(5000)
+            expect(onTimeoutMock).not.toHaveBeenCalled()
+
+            // Connection reestablished
+            watchdog.start()
+
+            jest.advanceTimersByTime(100)
+            watchdog.start()
+
+            jest.advanceTimersByTime(100)
+            watchdog.start()
+
+            // Should still work after recovery
+            jest.advanceTimersByTime(2000)
+            expect(onTimeoutMock).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('edge cases', () => {
+        it('should handle very rapid start calls', () => {
+            watchdog.start()
+
+            for (let i = 0; i < 1000; i++) {
+                watchdog.start()
+            }
+
+            jest.advanceTimersByTime(1999)
+            expect(onTimeoutMock).not.toHaveBeenCalled()
+
+            jest.advanceTimersByTime(1)
+            expect(onTimeoutMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('should only trigger timeout once', () => {
+            watchdog.start()
+
+            jest.advanceTimersByTime(2000)
+            expect(onTimeoutMock).toHaveBeenCalledTimes(1)
+
+            jest.advanceTimersByTime(5000)
+            expect(onTimeoutMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('should not interfere with multiple instances', () => {
+            const onTimeout2Mock = jest.fn()
+            const watchdog2 = new VMixConnectionWatchdog(onTimeout2Mock)
+
+            watchdog.start()
+            watchdog2.start()
+
+            jest.advanceTimersByTime(1000)
+
+            watchdog.stop()
+
+            jest.advanceTimersByTime(1000)
+
+            expect(onTimeoutMock).not.toHaveBeenCalled()
+            expect(onTimeout2Mock).toHaveBeenCalledTimes(1)
+
+            watchdog2.stop()
+        })
+    })
+})

--- a/server/src/utils/mixerConnections/productSpecific/__tests__/VMixConnectionWatchdog.spec.ts
+++ b/server/src/utils/mixerConnections/productSpecific/__tests__/VMixConnectionWatchdog.spec.ts
@@ -5,10 +5,11 @@ jest.useFakeTimers()
 describe('VMixConnectionWatchdog', () => {
     let onTimeoutMock: jest.Mock
     let watchdog: VMixConnectionWatchdog
+    const TIMEOUT_MS = 2000
 
     beforeEach(() => {
         onTimeoutMock = jest.fn()
-        watchdog = new VMixConnectionWatchdog(onTimeoutMock)
+        watchdog = new VMixConnectionWatchdog(onTimeoutMock, TIMEOUT_MS)
         jest.clearAllTimers()
     })
 
@@ -190,7 +191,10 @@ describe('VMixConnectionWatchdog', () => {
 
         it('should not interfere with multiple instances', () => {
             const onTimeout2Mock = jest.fn()
-            const watchdog2 = new VMixConnectionWatchdog(onTimeout2Mock)
+            const watchdog2 = new VMixConnectionWatchdog(
+                onTimeout2Mock,
+                TIMEOUT_MS
+            )
 
             watchdog.start()
             watchdog2.start()

--- a/server/src/utils/mixerConnections/productSpecific/__tests__/VMixPoller.spec.ts
+++ b/server/src/utils/mixerConnections/productSpecific/__tests__/VMixPoller.spec.ts
@@ -8,6 +8,10 @@ describe('VMixPoller', () => {
     let onFallbackMock: jest.Mock
     let poller: VMixPoller
 
+    const DEFAULT_POLL_INTERVAL_MS = 80
+    const DEFAULT_MIN_POLL_INTERVAL_MS = 20
+    const FALLBACK_POLL_INTERVAL_MS = 500
+
     beforeEach(() => {
         sendRequestMock = jest.fn()
         isConnectedMock = jest.fn(() => true)
@@ -15,7 +19,10 @@ describe('VMixPoller', () => {
         poller = new VMixPoller(
             sendRequestMock,
             isConnectedMock,
-            onFallbackMock
+            onFallbackMock,
+            DEFAULT_POLL_INTERVAL_MS,
+            DEFAULT_MIN_POLL_INTERVAL_MS,
+            FALLBACK_POLL_INTERVAL_MS
         )
         jest.clearAllTimers()
     })

--- a/server/src/utils/mixerConnections/productSpecific/__tests__/VMixPoller.spec.ts
+++ b/server/src/utils/mixerConnections/productSpecific/__tests__/VMixPoller.spec.ts
@@ -1,0 +1,273 @@
+import { VMixPoller } from '../VMixPoller'
+
+jest.useFakeTimers()
+
+describe('VMixPoller', () => {
+    let sendRequestMock: jest.Mock
+    let isConnectedMock: jest.Mock
+    let onFallbackMock: jest.Mock
+    let poller: VMixPoller
+
+    beforeEach(() => {
+        sendRequestMock = jest.fn()
+        isConnectedMock = jest.fn(() => true)
+        onFallbackMock = jest.fn()
+        poller = new VMixPoller(
+            sendRequestMock,
+            isConnectedMock,
+            onFallbackMock
+        )
+        jest.clearAllTimers()
+    })
+
+    afterEach(() => {
+        poller.stop()
+    })
+
+    describe('start', () => {
+        it('should send initial XML request in 80ms', () => {
+            poller.start()
+
+            jest.advanceTimersByTime(80)
+
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('should schedule fallback poll after sending request', () => {
+            poller.start()
+
+            jest.advanceTimersByTime(80)
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+
+            // Advance to fallback time (500ms from request)
+            jest.advanceTimersByTime(500)
+
+            expect(onFallbackMock).toHaveBeenCalledTimes(1)
+            expect(sendRequestMock).toHaveBeenCalledTimes(2)
+        })
+
+        it('should not send request if disconnected', () => {
+            isConnectedMock.mockReturnValue(false)
+
+            poller.start()
+
+            jest.advanceTimersByTime(100)
+
+            expect(sendRequestMock).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('onResponseReceived', () => {
+        it('should cancel fallback poll when response received', () => {
+            poller.start()
+
+            jest.advanceTimersByTime(80)
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+
+            // Receive response before fallback
+            poller.onResponseReceived()
+
+            // Advance past fallback time
+            jest.advanceTimersByTime(500)
+
+            // Fallback should not have triggered
+            expect(onFallbackMock).not.toHaveBeenCalled()
+        })
+
+        it('should schedule next poll after default interval when response received', () => {
+            poller.start()
+
+            jest.advanceTimersByTime(80)
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+
+            poller.onResponseReceived()
+
+            // Should send next request 80ms after response received
+            jest.advanceTimersByTime(80)
+
+            expect(sendRequestMock).toHaveBeenCalledTimes(2)
+        })
+
+        it('should account for processing time when scheduling next poll', () => {
+            poller.start()
+
+            jest.advanceTimersByTime(80)
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+
+            // Simulate 30ms of processing time
+            jest.advanceTimersByTime(30)
+            poller.onResponseReceived()
+
+            // Should send next request only 50ms later (80 - 30)
+            jest.advanceTimersByTime(50)
+
+            expect(sendRequestMock).toHaveBeenCalledTimes(2)
+        })
+
+        it('should respect minimum poll interval', () => {
+            poller.start()
+
+            jest.advanceTimersByTime(80)
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+
+            // Simulate 70ms of processing time
+            jest.advanceTimersByTime(70)
+            poller.onResponseReceived()
+
+            // Should wait at least 20ms (minimum interval)
+            jest.advanceTimersByTime(19)
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+
+            jest.advanceTimersByTime(1)
+            expect(sendRequestMock).toHaveBeenCalledTimes(2)
+        })
+
+        it('should handle multiple responses received in quick succession', () => {
+            poller.start()
+
+            jest.advanceTimersByTime(80)
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+
+            // Receive first response
+            poller.onResponseReceived()
+
+            // Receive second response immediately (e.g., duplicate or delayed packet)
+            // This should cancel the first scheduled poll and reschedule
+            poller.onResponseReceived()
+
+            // Should still respect minimum interval from the last request time
+            // Since both responses came immediately, we still need 80ms from the original request
+            jest.advanceTimersByTime(79)
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+
+            jest.advanceTimersByTime(1)
+            expect(sendRequestMock).toHaveBeenCalledTimes(2)
+        })
+    })
+
+    describe('stop', () => {
+        it('should cancel all pending timeouts', () => {
+            poller.start()
+
+            jest.advanceTimersByTime(80)
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+
+            poller.stop()
+
+            // Advance past all timeouts
+            jest.advanceTimersByTime(1000)
+
+            // Should not send any more requests
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('should not throw when called multiple times', () => {
+            poller.start()
+
+            expect(() => {
+                poller.stop()
+                poller.stop()
+                poller.stop()
+            }).not.toThrow()
+        })
+    })
+
+    describe('continuous polling cycle', () => {
+        it('should maintain polling cycle with regular responses', () => {
+            poller.start()
+
+            // First request
+            jest.advanceTimersByTime(80)
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+
+            // Response received, next request
+            poller.onResponseReceived()
+            jest.advanceTimersByTime(80)
+            expect(sendRequestMock).toHaveBeenCalledTimes(2)
+
+            // Response received, next request
+            poller.onResponseReceived()
+            jest.advanceTimersByTime(80)
+            expect(sendRequestMock).toHaveBeenCalledTimes(3)
+
+            // Fallback should never trigger
+            expect(onFallbackMock).not.toHaveBeenCalled()
+        })
+
+        it('should use fallback when no response received', () => {
+            poller.start()
+
+            jest.advanceTimersByTime(80)
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+
+            // No response received, fallback triggers (500ms from first request)
+            jest.advanceTimersByTime(500)
+            expect(onFallbackMock).toHaveBeenCalledTimes(1)
+            expect(sendRequestMock).toHaveBeenCalledTimes(2)
+
+            // Still no response, next fallback triggers (500ms from second request)
+            jest.advanceTimersByTime(500)
+            expect(onFallbackMock).toHaveBeenCalledTimes(2)
+            expect(sendRequestMock).toHaveBeenCalledTimes(3)
+        })
+
+        it('should recover from fallback mode when response received', () => {
+            poller.start()
+
+            jest.advanceTimersByTime(80)
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+
+            // No response, fallback triggers
+            jest.advanceTimersByTime(500)
+            expect(onFallbackMock).toHaveBeenCalledTimes(1)
+            expect(sendRequestMock).toHaveBeenCalledTimes(2)
+
+            // Response received, should switch back to normal interval
+            poller.onResponseReceived()
+            jest.advanceTimersByTime(80)
+            expect(sendRequestMock).toHaveBeenCalledTimes(3)
+
+            // Receive response before fallback would trigger
+            poller.onResponseReceived()
+
+            // Should not have triggered fallback
+            expect(onFallbackMock).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('connection state handling', () => {
+        it('should not send request when disconnected during timeout', () => {
+            poller.start()
+
+            jest.advanceTimersByTime(80)
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+
+            isConnectedMock.mockReturnValue(false)
+
+            poller.onResponseReceived()
+            jest.advanceTimersByTime(80)
+
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('should handle reconnection gracefully', () => {
+            poller.start()
+
+            jest.advanceTimersByTime(80)
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+
+            isConnectedMock.mockReturnValue(false)
+            poller.onResponseReceived()
+            jest.advanceTimersByTime(80)
+
+            expect(sendRequestMock).toHaveBeenCalledTimes(1)
+
+            // Reconnect
+            isConnectedMock.mockReturnValue(true)
+            poller.start()
+
+            jest.advanceTimersByTime(80)
+            expect(sendRequestMock).toHaveBeenCalledTimes(2)
+        })
+    })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -11579,7 +11579,7 @@ asn1@evs-broadcast/node-asn1:
     socket.io: "npm:^4.7.4"
     ts-jest: "npm:^29.1.2"
     tslib: "npm:^2.6.2"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:^5.6.3"
     vmix-js-utils: "npm:^4.0.19"
     web-midi-api: "npm:^2.2.5"
     webmidi: "npm:^2.5.1"
@@ -11625,10 +11625,10 @@ asn1@evs-broadcast/node-asn1:
 
 "shared@file:../shared::locator=server%40workspace%3Aserver":
   version: 0.0.0
-  resolution: "shared@file:../shared#../shared::hash=8d9975&locator=server%40workspace%3Aserver"
+  resolution: "shared@file:../shared#../shared::hash=6290eb&locator=server%40workspace%3Aserver"
   dependencies:
     redux: "npm:^5.0.1"
-  checksum: 10c0/7b7cd7efba75ecbcff8be7b56f68a9d05a726a8afba340146a498721b1c09c075bc58a6851b97e3f4d1d732f1551d4d8c1a2b9a0e797286ab8022e9ac7e9e714
+  checksum: 10c0/b9faf2fbf7c85c083b89761738db1f93eae7458bafc5f21b0e5b59dc760589c2867da8107f7b45fc6f72481a87325bb295990eeec8260fcb789c47e6fb23c18d
   languageName: node
   linkType: hard
 
@@ -12802,6 +12802,16 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.6.3":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@npm%3A^5.0.4#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
   version: 5.7.3
   resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=d69c25"
@@ -12809,6 +12819,16 @@ asn1@evs-broadcast/node-asn1:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/3b56d6afa03d9f6172d0b9cdb10e6b1efc9abc1608efd7a3d2f38773d5d8cfb9bbc68dfb72f0a7de5e8db04fc847f4e4baeddcd5ad9c9feda072234f0d788896
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.6.3#optional!builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=d69c25"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/6f7e53bf0d9702350deeb6f35e08b69cbc8b958c33e0ec77bdc0ad6a6c8e280f3959dcbfde6f5b0848bece57810696489deaaa53d75de3578ff255d168c1efbd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- applies back pressure and minimal threshold to prevent flooding vMix with too many requests
- prevents sisyfos from being flooded with more than it can process
- makes sure vMix is sending replies - if not, tries to reconnect
- adds logging in critical places
- fixes the event used for detecting disconnect
- reverts some changes regarding handing of silence
- prevents a crash due to sending xml request when the connection is lost
- bumps typescript because the server refused to build due to errors