### PR TITLE
fix(EAV-1000): vu-meter performance

### DIFF
--- a/.github/workflows/publish-lib.yaml
+++ b/.github/workflows/publish-lib.yaml
@@ -2,6 +2,7 @@ name: Publish prerelease
 
 env:
   node-version: 18
+  yarn-version: 4.1.0
   node-package-manager: yarn
 
 on:
@@ -28,6 +29,8 @@ jobs:
           node-version: ${{ env.node-version }}
       - name: Enable Corepack
         run: corepack enable
+      - name: Set Yarn Version
+        run: corepack prepare yarn@${{ env.yarn-version }} --activate
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -58,7 +61,8 @@ jobs:
       - name: Prepare Environment
         if: ${{ steps.do-publish.outputs.publish }}
         run: |
-          yarn install
+          yarn install --mode=update-lockfile
+          yarn install --mode=skip-build
           yarn build
         env:
           CI: true

--- a/client/src/components/SisyfosVuMeter.tsx
+++ b/client/src/components/SisyfosVuMeter.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 
 import '../assets/css/VuMeter.css'
 
-const FPS_INTERVAL = 1000 / 15
+const PAINT_INTERVAL = 1000 / 15
+const PEAK_WINDOW = 2000
+const BASE_HEIGHT = 400
 
 export interface SisyfosMeterConfig {
     min?: number
@@ -12,13 +15,8 @@ export interface SisyfosMeterConfig {
 }
 
 export interface SisyfosVuMeterProps {
-    level?: number
-    getLevel?: () => number
+    getLevel: () => number
     meterConfig?: SisyfosMeterConfig
-}
-
-interface SisyfosVuMeterState {
-    isVisible: boolean
 }
 
 const COLORS = {
@@ -31,237 +29,177 @@ const COLORS = {
     TOTAL_PEAK_HIGH: 'rgb(255, 0, 0)',
 }
 
-export class SisyfosVuMeter extends React.Component<
-    SisyfosVuMeterProps,
-    SisyfosVuMeterState
-> {
-    private canvas: HTMLCanvasElement | undefined
-    private canvasContext: CanvasRenderingContext2D | undefined
-    private animationFrame: number | undefined
-    private intersectionObserver: IntersectionObserver | null = null
+export function SisyfosVuMeter({
+    getLevel,
+    meterConfig,
+}: SisyfosVuMeterProps) {
+    const canvasRef = useRef<HTMLCanvasElement>(null)
+    const getLevelRef = useRef(getLevel)
+    getLevelRef.current = getLevel
 
-    private totalHeight = 400
-    private totalPeak = 0
-    private windowPeak = 0
-    private windowLast = 0
-    private meterMax = 1
-    private meterMin = 0
-    private range = 1
-    private meterTest = 0.75
-    private meterZero = 0.75
-    private readonly WINDOW = 2000
+    const totalPeakRef = useRef(0)
+    const dirtyRef = useRef(false)
 
-    private previousValue = -1
-    private value = 0
-
-    private lastUpdateTime = Date.now()
-
-    constructor(props: SisyfosVuMeterProps) {
-        super(props)
-        this.state = {
-            isVisible: false,
+    const { totalHeight, range, meterTest, meterZero } = useMemo(() => {
+        const max = meterConfig?.max ?? 1
+        const min = meterConfig?.min ?? 0
+        const range = max - min
+        return {
+            range,
+            totalHeight: BASE_HEIGHT / range,
+            meterTest: meterConfig?.test ?? 0.75,
+            meterZero: meterConfig?.zero ?? 0.75,
         }
-        this.applyMeterConfig(props.meterConfig)
-    }
+    }, [meterConfig])
 
-    componentDidMount() {
-        this.initIntersectionObserver()
-        this.initializeCanvas()
-        this.paintVuMeter()
-    }
+    useEffect(() => {
+        const canvas = canvasRef.current
+        if (!canvas) return
+        const canvasContext = canvas.getContext('2d')
+        if (!canvasContext) return
 
-    componentDidUpdate(prevProps: SisyfosVuMeterProps) {
-        if (prevProps.meterConfig !== this.props.meterConfig) {
-            this.applyMeterConfig(this.props.meterConfig)
-            this.initializeCanvas()
-        }
-    }
+        let animationFrame: number | undefined
+        let previousValue = -1
+        let lastPaintTime = 0
+        let windowPeak = 0
+        let windowLast = 0
 
-    componentWillUnmount() {
-        if (this.animationFrame) {
-            cancelAnimationFrame(this.animationFrame)
-        }
+        const paint = (now: DOMHighResTimeStamp) => {
+            animationFrame = requestAnimationFrame(paint)
 
-        if (this.intersectionObserver && this.canvas) {
-            this.intersectionObserver.unobserve(this.canvas)
-            this.intersectionObserver.disconnect()
-        }
-    }
+            if (now - lastPaintTime < PAINT_INTERVAL) return
 
-    shouldComponentUpdate(): boolean {
-        const currentTime = Date.now()
-        if (currentTime - this.lastUpdateTime < FPS_INTERVAL) {
-            return false
-        }
-        this.lastUpdateTime = currentTime
-        return true
-    }
+            const value = getLevelRef.current()
 
-    private applyMeterConfig(meterConfig?: SisyfosMeterConfig) {
-        this.meterMax = meterConfig?.max ?? 1
-        this.meterMin = meterConfig?.min ?? 0
-        this.range = this.meterMax - this.meterMin
-        this.meterTest = meterConfig?.test ?? 0.75
-        this.meterZero = meterConfig?.zero ?? 0.75
-    }
-
-    private getCurrentLevel() {
-        if (this.props.getLevel) {
-            return this.props.getLevel()
-        }
-        return this.props.level ?? 0
-    }
-
-    private initializeCanvas() {
-        if (!this.canvas) return
-
-        this.canvasContext = this.canvas.getContext('2d', {
-            antialias: false,
-            stencil: false,
-            preserveDrawingBuffer: true,
-        }) as CanvasRenderingContext2D
-
-        this.totalHeight =
-            (this.canvas.height ?? 400) / (this.meterMax - this.meterMin)
-    }
-
-    private initIntersectionObserver() {
-        this.intersectionObserver = new IntersectionObserver(
-            (entries) => {
-                const [entry] = entries
-                this.setState({ isVisible: entry.isIntersecting })
-            },
-            {
-                threshold: 0.1,
+            const windowStale =
+                now - windowLast > PEAK_WINDOW && windowPeak !== value
+            if (
+                value === previousValue &&
+                !windowStale &&
+                !dirtyRef.current
+            ) {
+                return
             }
-        )
+            lastPaintTime = now
+            previousValue = value
+            dirtyRef.current = false
 
-        if (this.canvas) {
-            this.intersectionObserver.observe(this.canvas)
+            if (value > windowPeak || now - windowLast > PEAK_WINDOW) {
+                windowPeak = value
+                windowLast = now
+            }
+            if (value > totalPeakRef.current) {
+                totalPeakRef.current = value
+            }
+            const totalPeak = totalPeakRef.current
+
+            const lower = totalHeight * Math.min(value, meterTest)
+            const middle =
+                totalHeight *
+                    (Math.max(meterTest, Math.min(value, meterZero)) -
+                        meterTest) +
+                1
+            const upper =
+                totalHeight * (Math.max(meterZero, value) - meterZero) + 1
+
+            canvasContext.clearRect(0, 0, canvas.width, canvas.height)
+
+            canvasContext.fillStyle = COLORS.LOWER
+            canvasContext.fillRect(
+                0,
+                totalHeight - lower,
+                canvas.width,
+                lower
+            )
+
+            canvasContext.fillStyle = COLORS.MIDDLE
+            canvasContext.fillRect(
+                0,
+                totalHeight * (range - meterTest) - middle,
+                canvas.width,
+                middle
+            )
+
+            canvasContext.fillStyle = COLORS.UPPER
+            canvasContext.fillRect(
+                0,
+                totalHeight * (range - meterZero) - upper,
+                canvas.width,
+                upper
+            )
+
+            canvasContext.fillStyle =
+                windowPeak < meterZero
+                    ? COLORS.WINDOW_PEAK_LOW
+                    : COLORS.WINDOW_PEAK_HIGH
+            canvasContext.fillRect(
+                0,
+                totalHeight - totalHeight * windowPeak,
+                canvas.width,
+                2
+            )
+
+            canvasContext.fillStyle =
+                totalPeak < meterZero
+                    ? COLORS.TOTAL_PEAK_LOW
+                    : COLORS.TOTAL_PEAK_HIGH
+            canvasContext.fillRect(
+                0,
+                totalHeight - totalHeight * totalPeak,
+                canvas.width,
+                2
+            )
         }
-    }
 
-    private getTotalPeak = () => {
-        if (this.value > this.totalPeak) {
-            this.totalPeak = this.value
+        const start = () => {
+            if (animationFrame === undefined) {
+                animationFrame = requestAnimationFrame(paint)
+            }
         }
-        return this.totalHeight * this.totalPeak
-    }
-
-    private getWindowPeak = () => {
-        if (this.value > this.windowPeak || Date.now() - this.windowLast > this.WINDOW) {
-            this.windowPeak = this.value
-            this.windowLast = Date.now()
-        }
-        return this.totalHeight * this.windowPeak
-    }
-
-    private calcLower = () => {
-        return this.totalHeight * Math.min(this.value, this.meterTest)
-    }
-
-    private calcMiddle = () => {
-        const val = Math.max(this.meterTest, Math.min(this.value, this.meterZero))
-        return this.totalHeight * (val - this.meterTest) + 1
-    }
-
-    private calcUpper = () => {
-        const val = Math.max(this.meterZero, this.value)
-        return this.totalHeight * (val - this.meterZero) + 1
-    }
-
-    private setRef = (el: HTMLCanvasElement) => {
-        this.canvas = el
-        this.initializeCanvas()
-        this.paintVuMeter()
-    }
-
-    private resetTotalPeak = () => {
-        this.totalPeak = 0
-    }
-
-    private paintVuMeter = () => {
-        if (!this.canvas || !this.canvasContext) {
-            this.animationFrame = requestAnimationFrame(this.paintVuMeter)
-            return
+        const stop = () => {
+            if (animationFrame !== undefined) {
+                cancelAnimationFrame(animationFrame)
+                animationFrame = undefined
+            }
         }
 
-        this.value = this.getCurrentLevel()
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                if (entry.isIntersecting) {
+                    start()
+                } else {
+                    stop()
+                }
+            },
+            { threshold: 0.1 }
+        )
+        observer.observe(canvas)
 
-        if (this.value === this.previousValue) {
-            window.requestAnimationFrame(this.paintVuMeter)
-            return
+        return () => {
+            stop()
+            observer.disconnect()
         }
-        this.previousValue = this.value
+    }, [totalHeight, range, meterTest, meterZero])
 
-        this.canvasContext.clearRect(0, 0, this.canvas.width, this.canvas.height)
-
-        this.canvasContext.fillStyle = COLORS.LOWER
-        this.canvasContext.fillRect(
-            0,
-            this.totalHeight - this.calcLower(),
-            this.canvas.height,
-            this.calcLower()
-        )
-
-        this.canvasContext.fillStyle = COLORS.MIDDLE
-        this.canvasContext.fillRect(
-            0,
-            this.totalHeight * (this.range - this.meterTest) - this.calcMiddle(),
-            this.canvas.width,
-            this.calcMiddle()
-        )
-
-        this.canvasContext.fillStyle = COLORS.UPPER
-        this.canvasContext.fillRect(
-            0,
-            this.totalHeight * (this.range - this.meterZero) - this.calcUpper(),
-            this.canvas.width,
-            this.calcUpper()
-        )
-
-        const windowPeak = this.getWindowPeak()
-        this.canvasContext.fillStyle =
-            this.windowPeak < this.meterZero
-                ? COLORS.WINDOW_PEAK_LOW
-                : COLORS.WINDOW_PEAK_HIGH
-        this.canvasContext.fillRect(
-            0,
-            this.totalHeight - windowPeak,
-            this.canvas.width,
-            2
-        )
-
-        this.canvasContext.fillStyle =
-            this.totalPeak < this.meterZero
-                ? COLORS.TOTAL_PEAK_LOW
-                : COLORS.TOTAL_PEAK_HIGH
-        this.canvasContext.fillRect(
-            0,
-            this.totalHeight - this.getTotalPeak(),
-            this.canvas.width,
-            2
-        )
-
-        window.requestAnimationFrame(this.paintVuMeter)
+    const resetTotalPeak = () => {
+        totalPeakRef.current = 0
+        dirtyRef.current = true
     }
 
-    render() {
-        return (
-            <div className="vumeter-body" onClick={this.resetTotalPeak}>
-                <canvas
-                    className="vumeter-canvas"
-                    style={{
-                        height: this.totalHeight,
-                        top: '10px',
-                    }}
-                    height={this.totalHeight}
-                    width={10}
-                    ref={this.setRef}
-                ></canvas>
-            </div>
-        )
-    }
+    return (
+        <div className="vumeter-body" onClick={resetTotalPeak}>
+            <canvas
+                className="vumeter-canvas"
+                style={{
+                    height: totalHeight,
+                    top: '10px',
+                }}
+                height={totalHeight}
+                width={10}
+                ref={canvasRef}
+            ></canvas>
+        </div>
+    )
 }
 
 export default SisyfosVuMeter

--- a/client/src/utils/labels.ts
+++ b/client/src/utils/labels.ts
@@ -13,19 +13,37 @@ export function getSisyfosReduxState(): ReduxStore {
     return activeStore.getState() as ReduxStore
 }
 
+let channelLabelCacheConnections: ReduxStore['channels'][0]['chMixerConnection'] | undefined
+let channelLabelCache: Map<number, string> | undefined
+
+function getChannelLabelsByFader(
+    chMixerConnection: ReduxStore['channels'][0]['chMixerConnection'],
+): Map<number, string> {
+    if (chMixerConnection === channelLabelCacheConnections && channelLabelCache) {
+        return channelLabelCache
+    }
+
+    const labelsByFader = new Map<number, string>()
+    for (const conn of chMixerConnection) {
+        for (const ch of conn.channel) {
+            if (ch.label && !labelsByFader.has(ch.assignedFader)) {
+                labelsByFader.set(ch.assignedFader, ch.label)
+            }
+        }
+    }
+
+    channelLabelCacheConnections = chMixerConnection
+    channelLabelCache = labelsByFader
+    return labelsByFader
+}
+
 export function getChannelLabel(
     state: ReduxStore,
     faderIndex: number,
 ): string | undefined {
-    let label = state.channels[0].chMixerConnection
-        .flatMap((conn) =>
-            conn.channel.map((ch) => ({
-                assignedFader: ch.assignedFader,
-                label: ch.label,
-            })),
-        )
-        .filter((ch) => ch.label && ch.label !== '')
-        .find((ch) => ch.assignedFader === faderIndex)?.label
+    let label = getChannelLabelsByFader(
+        state.channels[0].chMixerConnection,
+    ).get(faderIndex)
     if (
         state.settings[0].labelControlsIgnoreAutomation &&
         label?.startsWith(state.settings[0].labelIgnorePrefix)

--- a/component-lib/package.json
+++ b/component-lib/package.json
@@ -21,6 +21,7 @@
   "types": "./dist/component-lib/src/index.d.ts",
   "dependencies": {
     "@floating-ui/react": "^0.26.20",
+    "@reduxjs/toolkit": "^2.0.0",
     "classnames": "^2.5.1",
     "i18next": "^20.6.1",
     "i18next-browser-languagedetector": "^7.2.0",

--- a/component-lib/rollup.config.mjs
+++ b/component-lib/rollup.config.mjs
@@ -4,6 +4,13 @@ import typescript from '@rollup/plugin-typescript';
 import commonjs from '@rollup/plugin-commonjs';
 import svgr from '@svgr/rollup';
 import path from 'path';
+import { createRequire } from 'module';
+
+const pkg = createRequire(import.meta.url)('./package.json');
+const externalPackages = [
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.peerDependencies ?? {}),
+];
 
 export default {
   input: './src/index.tsx', // Entry point of the component library
@@ -30,8 +37,12 @@ export default {
     }),
     svgr()
   ],
-  external: [
-    'react', // Prevent bundling react
-    'react-dom' // Prevent bundling react-dom
-  ],
+  // Anything the package declares as a dependency/peerDependency is the
+  // consumer's responsibility to provide, not ours to bundle. Deriving this
+  // from package.json (rather than a hand-maintained list) keeps it in sync
+  // automatically and stops Rollup from warning about every one of them as
+  // an "unresolved" external it had to guess about.
+  external: (id) => externalPackages.some(
+    (name) => id === name || id.startsWith(`${name}/`)
+  ),
 };

--- a/component-lib/src/index.tsx
+++ b/component-lib/src/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import { Provider as LegacyReduxProvider } from 'react-redux'
+import { Provider as SisyfosReduxProvider } from 'react-redux'
 import { useSocketConnection } from '../../client/src/hooks/useSocketConnection'
 import ContextProvider from '../../client/src/components/ContextProvider'
 import OrgChannels from '../../client/src/components/Channels'
 import SisyfosVuMeter from '../../client/src/components/SisyfosVuMeter'
 import upstreamI18n from '../../client/src/utils/i18n'
 import { vuMeters } from '../../client/src/utils/SocketClientHandlers'
-import legacyStore from '../../shared/src/reducers/store'
+import sisyfosStore from '../../shared/src/reducers/store'
 
 export { I18nextProvider } from 'react-i18next'
 export { ChannelActionTypes } from '../../shared/src/actions/channelActions'
@@ -21,8 +21,8 @@ export function Channels({ page }: { page?: string }) {
 
 export {
     ContextProvider,
-    LegacyReduxProvider,
-    legacyStore,
+    SisyfosReduxProvider,
+    sisyfosStore,
     SisyfosVuMeter,
     upstreamI18n,
     useSocketConnection,
@@ -34,7 +34,6 @@ export type {
     RootAction as SisyfosAction,
 } from '../../shared/src/reducers/indexReducer'
 export type {
-    Faders,
     Fader,
     VuMeters,
     ChannelReference,
@@ -45,11 +44,5 @@ export type {
     ChMixerConnection,
     NumberOfChannels,
 } from '../../shared/src/reducers/channelsReducer'
-export type { Settings } from '../../shared/src/reducers/settingsReducer'
-export type { ReduxStore as LegacyReduxStore } from '../../shared/src/reducers/store'
-export type { Channels as LegacyChannels } from '../../shared/src/reducers/channelsReducer'
-export type { Faders as LegacyFaders } from '../../shared/src/reducers/fadersReducer'
-export type {
-    CustomPages as LegacyCustomPages,
-} from '../../shared/src/reducers/settingsReducer'
+export type { Settings, CustomPages } from '../../shared/src/reducers/settingsReducer'
 export type { SisyfosMeterConfig } from '../../client/src/components/SisyfosVuMeter'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2089,6 +2089,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@reduxjs/toolkit@npm:^2.0.0":
+  version: 2.12.0
+  resolution: "@reduxjs/toolkit@npm:2.12.0"
+  dependencies:
+    "@standard-schema/spec": "npm:^1.0.0"
+    "@standard-schema/utils": "npm:^0.3.0"
+    immer: "npm:^11.0.0"
+    redux: "npm:^5.0.1"
+    redux-thunk: "npm:^3.1.0"
+    reselect: "npm:^5.1.0"
+  peerDependencies:
+    react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+    react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-redux:
+      optional: true
+  checksum: 10c0/2b85e31294a7139994fd78b08eb3ce706ce3b03b5081c13403b93ba4883a152d637171e4d9d969766238851f8915b1daa9f36b5a0a458aff0ff7600ee38795c9
+  languageName: node
+  linkType: hard
+
 "@reduxjs/toolkit@npm:^2.1.0":
   version: 2.5.1
   resolution: "@reduxjs/toolkit@npm:2.5.1"
@@ -2480,6 +2502,20 @@ __metadata:
   version: 3.1.2
   resolution: "@socket.io/component-emitter@npm:3.1.2"
   checksum: 10c0/c4242bad66f67e6f7b712733d25b43cbb9e19a595c8701c3ad99cbeb5901555f78b095e24852f862fffb43e96f1d8552e62def885ca82ae1bb05da3668fd87d7
+  languageName: node
+  linkType: hard
+
+"@standard-schema/spec@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@standard-schema/spec@npm:1.1.0"
+  checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
+  languageName: node
+  linkType: hard
+
+"@standard-schema/utils@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@standard-schema/utils@npm:0.3.0"
+  checksum: 10c0/6eb74cd13e52d5fc74054df51e37d947ef53f3ab9e02c085665dcca3c38c60ece8d735cebbdf18fbb13c775fbcb9becb3f53109b0e092a63f0f7389ce0993fd0
   languageName: node
   linkType: hard
 
@@ -7202,6 +7238,13 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
+"immer@npm:^11.0.0":
+  version: 11.1.15
+  resolution: "immer@npm:11.1.15"
+  checksum: 10c0/5215eaec9641ad786ae8940a489514c26ce3726f8c49f0191a754902800f3ddd102b0653e894cabe7049d93e77b86d67d19953e778ffebba56848739a31b3b79
+  languageName: node
+  linkType: hard
+
 "import-cwd@npm:^3.0.0":
   version: 3.0.0
   resolution: "import-cwd@npm:3.0.0"
@@ -11759,6 +11802,7 @@ asn1@evs-broadcast/node-asn1:
     "@babel/preset-react": "npm:^7.24.7"
     "@babel/preset-typescript": "npm:^7.24.7"
     "@floating-ui/react": "npm:^0.26.20"
+    "@reduxjs/toolkit": "npm:^2.0.0"
     "@rollup/plugin-babel": "npm:^6.0.4"
     "@rollup/plugin-commonjs": "npm:^26.0.1"
     "@rollup/plugin-typescript": "npm:^11.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9331,7 +9331,7 @@ asn1@evs-broadcast/node-asn1:
   dependencies:
     axios: "npm:^1.7.3"
     querystring: "npm:^0.2.1"
-  checksum: 10c0/9e6af1bb357cfce7397563b942a2d74f622ec446ecbb05bd35441b1e01cc002a40945a768496cf2ac6625bcc7a83cae95e28f4f935addbc675fc1205f8ab58de
+  checksum: 10c0/9f4f0d8b22260eb66518bb420baf46157121bc994221d5deb59d5ffb50a62b1ad21c64032fc3c50eb6908e39b0ebf99bffc46cf77acb0adb18f819062b6c2c52
   languageName: node
   linkType: hard
 
@@ -11625,10 +11625,10 @@ asn1@evs-broadcast/node-asn1:
 
 "shared@file:../shared::locator=server%40workspace%3Aserver":
   version: 0.0.0
-  resolution: "shared@file:../shared#../shared::hash=2e2f16&locator=server%40workspace%3Aserver"
+  resolution: "shared@file:../shared#../shared::hash=bc2dca&locator=server%40workspace%3Aserver"
   dependencies:
     redux: "npm:^5.0.1"
-  checksum: 10c0/2927cc13c9571233b98570df4a6c80404cad9d7cc603607b5a625a7e5a7602d85db15dd82172c62ec0821879c11d50b51c166ec2f71e7e15386e073fc8d59ff1
+  checksum: 10c0/ec86227007f88e6efee8907bac44728191076934c56f98458167d7edca1b7e22abfead6502a957dec0a02295da23ecf999e19872de075b1e09ae0d9bcbf7d9c8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- The class component was replaced with hooks to reduce VU-meter overhead:
- The old code accidentally started the paint loop from both the ref callback and componentDidMount.
- Most scheduled frames were not stored in `this.animationFrame`, so unmounting could not reliably cancel them.
- The old intersection observer only updated unused React state; it never actually stopped animation.
- The new implementation maintains one guarded loop, stops it off-screen, cancels it during cleanup, and limits canvas redraws to roughly 15 FPS.
- Peaks and dirty/reset state moved into refs, avoiding React renders.
- getLevel is held in a ref so changing callback identity does not restart the effect.
- Window peaks now expire even if the incoming level stops changing.